### PR TITLE
Async write to prevent blocking of the calling thread

### DIFF
--- a/Sources/AtomicWrite/AtomicWrite.swift
+++ b/Sources/AtomicWrite/AtomicWrite.swift
@@ -51,7 +51,7 @@ public struct AtomicWrite<Value> {
             return queue.sync { storage }
         }
         set {
-            queue.sync(flags: .barrier) { storage = newValue }
+            queue.async(flags: .barrier) { storage = newValue }
         }
     }
     
@@ -59,7 +59,7 @@ public struct AtomicWrite<Value> {
     ///
     /// - parameter action: A closure executed with atomic in-out access to the wrapped property.
     public mutating func mutate(_ mutation: (inout Value) throws -> Void) rethrows {
-        return try queue.sync(flags: .barrier) {
+        return try queue.async(flags: .barrier) {
             try mutation(&storage)
         }
     }


### PR DESCRIPTION
Reads are still concurrent (from different threads), but writes won't block the calling thread.