### PR TITLE
Improve AtomicWrite performance with pthread_mutex and os_unfair_lock

### DIFF
--- a/Sources/AtomicWrite/AtomicWrite.swift
+++ b/Sources/AtomicWrite/AtomicWrite.swift
@@ -18,7 +18,7 @@ import Foundation
 /// purpose which you can access with a $ prefix.
 ///
 /// ```
-/// @Atomic var count = 0
+/// @AtomicWrite var count = 0
 ///
 /// // You can atomically write (non-derived) values directly:
 /// count = 100
@@ -33,25 +33,28 @@ import Foundation
 /// [swift-evolution proposal](https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md)
 /// [ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Sources/Atomic.swift)
 /// [obj.io](https://www.objc.io/blog/2019/01/15/atomic-variables-part-2/)
-@available(iOS 2.0, OSX 10.0, tvOS 9.0, watchOS 2.0, *)
 @propertyWrapper
 public struct AtomicWrite<Value> {
-    
-    // TODO: Faster version with os_unfair_lock?
-    
-    let queue = DispatchQueue(label: "Atomic write access queue", attributes: .concurrent)
     var storage: Value
     
+    private let lock: AtomicLock = {
+        if #available(OSX 10.12, iOS 10, tvOS 10, watchOS 3, *) {
+            return UnfairLock()
+        } else {
+            return PThreadLock()
+        }
+    }()
+
     public init(initialValue value: Value) {
         self.storage = value
     }
     
     public var wrappedValue: Value {
         get {
-            return queue.sync { storage }
+            return lock.perform { storage }
         }
         set {
-            queue.sync(flags: .barrier) { storage = newValue }
+            lock.perform { storage = newValue }
         }
     }
     
@@ -59,8 +62,42 @@ public struct AtomicWrite<Value> {
     ///
     /// - parameter action: A closure executed with atomic in-out access to the wrapped property.
     public mutating func mutate(_ mutation: (inout Value) throws -> Void) rethrows {
-        return try queue.sync(flags: .barrier) {
+        return try lock.perform {
             try mutation(&storage)
         }
     }
 }
+
+private protocol AtomicLock {
+    func perform<Result>(block: () throws -> Result) rethrows -> Result
+}
+
+private class PThreadLock: AtomicLock {
+    private var mutex = pthread_mutex_t()
+
+    init() {
+        pthread_mutex_init(&mutex, nil)
+    }
+
+    deinit {
+        pthread_mutex_destroy(&mutex)
+    }
+
+    func perform<Result>(block: () throws -> Result) rethrows -> Result {
+        pthread_mutex_lock(&mutex)
+        defer { pthread_mutex_unlock(&mutex) }
+        return try block()
+    }
+}
+
+@available(OSX 10.12, iOS 10, tvOS 10, watchOS 3, *)
+private class UnfairLock: AtomicLock {
+    private var mutex = os_unfair_lock()
+
+    func perform<Result>(block: () throws -> Result) rethrows -> Result {
+        os_unfair_lock_lock(&mutex)
+        defer { os_unfair_lock_unlock(&mutex) }
+        return try block()
+    }
+}
+


### PR DESCRIPTION
Use `os_unfair_lock` if it is available, otherwise fall back to  `pthread_mutex`. 

This should give a nice performance boost according to the tests in this article:
https://www.cocoawithlove.com/blog/2016/06/02/threads-and-mutexes.html