### PR TITLE
Add `Optional` conformance to `PropertyListValue`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "Burritos",
     platforms: [
     .macOS(.v10_10),
-            .iOS(.v8),
+            .iOS(.v9),
             .tvOS(.v9),
             .watchOS(.v2)
     ],

--- a/Sources/UserDefault/UserDefault.swift
+++ b/Sources/UserDefault/UserDefault.swift
@@ -77,3 +77,5 @@ extension Float80: PropertyListValue {}
 extension Array: PropertyListValue where Element: PropertyListValue {}
 
 extension Dictionary: PropertyListValue where Key == String, Value: PropertyListValue {}
+
+extension Optional: PropertyListValue where Wrapped: PropertyListValue {}


### PR DESCRIPTION
- add conformance of `Optional` to `PropertyListValue` if `Wrapped` conforms
- as side effect I updated SPM deployment target to silence Xcode warnings